### PR TITLE
feat: ShowtimeResponse 객체와 직렬화 Config 추가

### DIFF
--- a/src/main/java/com/safeticket/common/config/JacksonConfig.java
+++ b/src/main/java/com/safeticket/common/config/JacksonConfig.java
@@ -1,0 +1,18 @@
+package com.safeticket.common.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.hibernate5.Hibernate5Module;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class JacksonConfig {
+    @Bean
+    public ObjectMapper objectMapper() {
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.registerModule(new Hibernate5Module());
+        objectMapper.registerModule(new JavaTimeModule());
+        return objectMapper;
+    }
+}

--- a/src/main/java/com/safeticket/event/EventController.java
+++ b/src/main/java/com/safeticket/event/EventController.java
@@ -1,0 +1,36 @@
+package com.safeticket.event;
+
+import com.safeticket.event.dto.EventResponse;
+import com.safeticket.event.entity.Event;
+import com.safeticket.event.service.EventService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/events")
+public class EventController {
+
+    private final EventService eventService;
+
+    @GetMapping("/{id}")
+    public ResponseEntity<EventResponse> getEventById(@PathVariable Long id) {
+        return ResponseEntity.ok(EventResponse.of(eventService.getEventById(id)));
+    }
+
+    @GetMapping("/{id}/showtimes")
+    public ResponseEntity<EventResponse> getEventByIdWithShowtimes(@PathVariable Long id) {
+        return ResponseEntity.ok(EventResponse.of(eventService.getEventByIdWithShowtimes(id)));
+    }
+
+    @GetMapping
+    public List<Event> getAllEvents() {
+        return eventService.getAllEvents();
+    }
+}

--- a/src/main/java/com/safeticket/event/dto/EventResponse.java
+++ b/src/main/java/com/safeticket/event/dto/EventResponse.java
@@ -1,12 +1,15 @@
 package com.safeticket.event.dto;
 
 import com.safeticket.event.entity.Event;
+import com.safeticket.showtime.dto.ShowtimeResponse;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.List;
 
 @Builder
 @Getter
@@ -18,6 +21,7 @@ public class EventResponse {
     private String description;
     private Integer durationMinutes;
     private String status;
+    private List<ShowtimeResponse> showtimes;
 
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
@@ -29,6 +33,7 @@ public class EventResponse {
                 .description(event.getDescription())
                 .durationMinutes(event.getDurationMinutes())
                 .status(event.getStatus().getStatus())
+                .showtimes(event.getShowtimes() == null ? null : ShowtimeResponse.ofList(event.getShowtimes()))
                 .createdAt(event.getCreatedAt())
                 .updatedAt(event.getUpdatedAt())
                 .build();

--- a/src/main/java/com/safeticket/event/service/EventServiceImpl.java
+++ b/src/main/java/com/safeticket/event/service/EventServiceImpl.java
@@ -4,7 +4,9 @@ import com.safeticket.event.entity.Event;
 import com.safeticket.event.EventRepository;
 import com.safeticket.event.exception.EventNotFoundException;
 import lombok.RequiredArgsConstructor;
+import org.hibernate.Hibernate;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
@@ -15,6 +17,7 @@ public class EventServiceImpl implements EventService {
     private final EventRepository eventRepository;
 
     @Override
+    @Transactional(readOnly = true)
     public Event getEventById(Long id) {
         return eventRepository.findById(id)
                 .orElseThrow(() -> new EventNotFoundException(id));
@@ -23,5 +26,10 @@ public class EventServiceImpl implements EventService {
     @Override
     public List<Event> getAllEvents() {
         return eventRepository.findAll();
+    }
+
+    public Event getEventByIdWithShowtimes(Long id) {
+        return eventRepository.findByIdWithShowtimes(id)
+                .orElseThrow(() -> new EventNotFoundException(id));
     }
 }

--- a/src/main/java/com/safeticket/showtime/dto/ShowtimeResponse.java
+++ b/src/main/java/com/safeticket/showtime/dto/ShowtimeResponse.java
@@ -1,0 +1,55 @@
+package com.safeticket.showtime.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.safeticket.event.entity.Event;
+import com.safeticket.showtime.entity.Showtime;
+import com.safeticket.venue.entity.Venue;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Builder
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonIgnoreProperties({"hibernateLazyInitializer", "handler"})
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+public class ShowtimeResponse {
+    private Long id;
+    private LocalDateTime startTime;
+    private LocalDateTime endTime;
+    private Event event;
+    private Venue venue;
+
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+
+    public static ShowtimeResponse of(Showtime showtime) {
+        if (showtime == null) {
+            return null;
+        }
+        return ShowtimeResponse.builder()
+                .id(showtime.getId())
+                .startTime(showtime.getStartTime())
+                .endTime(showtime.getEndTime())
+                .event(showtime.getEvent())
+                .venue(showtime.getVenue())
+                .createdAt(showtime.getCreatedAt())
+                .updatedAt(showtime.getUpdatedAt())
+                .build();
+    }
+
+    public static List<ShowtimeResponse> ofList(List<Showtime> showtimes) {
+        return (showtimes == null) ? Collections.emptyList()
+                : showtimes.stream().map(ShowtimeResponse::of).collect(Collectors.toList());
+    }
+
+
+}


### PR DESCRIPTION
📌 변경 사항
- 직렬화 하기위한 JacksonConfig 추가
- ShowtimeResponse DTO 추가

🤔 고민한 점
- 서로 연관된 테이블끼리 Response를 할때 내부에 어떻게 해야 좋을지(EventResponse에서 List<ShowtimeResponse> 필드)
- GET /events/{id} 를 요청하였을 때 ShowtimeResponse 내부에 연관 엔티티 객체로 인해 문제 발생(프록시 객체를 직렬화하면서)을 JacksonConfig를 추가하여 해결했지만 옳바른 방법인지 아니면 더 좋은방법이 없는지 아직도 고민중입니다.