### PR TITLE
feat: 공통 GlobalExceptionHandler와 BaseTimeEntity 추가

### DIFF
--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,4 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
-  <component name="VcsDirectoryMappings" defaultProject="true" />
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
 </project>

--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,8 @@ repositories {
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.hibernate:hibernate-core:6.2.7.Final'
+    implementation 'mysql:mysql-connector-java:8.0.33'
 
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/com/safeticket/SafeTicketApplication.java
+++ b/src/main/java/com/safeticket/SafeTicketApplication.java
@@ -2,8 +2,10 @@ package com.safeticket;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableJpaAuditing
 public class SafeTicketApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/com/safeticket/common/advice/GlobalExceptionHandler.java
+++ b/src/main/java/com/safeticket/common/advice/GlobalExceptionHandler.java
@@ -1,0 +1,25 @@
+package com.safeticket.common.advice;
+
+import com.safeticket.event.exception.EventNotFoundException;
+import com.safeticket.showtime.exception.ShowtimeNotFoundException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(EventNotFoundException.class)
+    @ResponseStatus(HttpStatus.NOT_FOUND)
+    public ResponseEntity<String> handleEventNotFoundException(EventNotFoundException ex) {
+        return new ResponseEntity<>(ex.getMessage(), HttpStatus.NOT_FOUND);
+    }
+
+    @ExceptionHandler(ShowtimeNotFoundException.class)
+    @ResponseStatus(HttpStatus.NOT_FOUND)
+    public ResponseEntity<String> handleShowtimeNotFoundException(ShowtimeNotFoundException ex) {
+        return new ResponseEntity<>(ex.getMessage(), HttpStatus.NOT_FOUND);
+    }
+}

--- a/src/main/java/com/safeticket/common/config/JacksonConfig.java
+++ b/src/main/java/com/safeticket/common/config/JacksonConfig.java
@@ -1,0 +1,18 @@
+package com.safeticket.common.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.hibernate5.Hibernate5Module;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class JacksonConfig {
+    @Bean
+    public ObjectMapper objectMapper() {
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.registerModule(new Hibernate5Module());
+        objectMapper.registerModule(new JavaTimeModule());
+        return objectMapper;
+    }
+}

--- a/src/main/java/com/safeticket/common/util/BaseTimeEntity.java
+++ b/src/main/java/com/safeticket/common/util/BaseTimeEntity.java
@@ -1,0 +1,23 @@
+package com.safeticket.common.util;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseTimeEntity {
+    @CreatedDate
+    @Column(nullable = false, updatable = false)
+    protected LocalDateTime createdAt;
+
+    @LastModifiedDate
+    protected LocalDateTime updatedAt;
+}

--- a/src/main/java/com/safeticket/event/EventController.java
+++ b/src/main/java/com/safeticket/event/EventController.java
@@ -1,0 +1,36 @@
+package com.safeticket.event;
+
+import com.safeticket.event.dto.EventResponse;
+import com.safeticket.event.entity.Event;
+import com.safeticket.event.service.EventService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/events")
+public class EventController {
+
+    private final EventService eventService;
+
+    @GetMapping("/{id}")
+    public ResponseEntity<EventResponse> getEventById(@PathVariable Long id) {
+        return ResponseEntity.ok(EventResponse.of(eventService.getEventById(id)));
+    }
+
+    @GetMapping("/{id}/showtimes")
+    public ResponseEntity<EventResponse> getEventByIdWithShowtimes(@PathVariable Long id) {
+        return ResponseEntity.ok(EventResponse.of(eventService.getEventByIdWithShowtimes(id)));
+    }
+
+    @GetMapping
+    public List<Event> getAllEvents() {
+        return eventService.getAllEvents();
+    }
+}

--- a/src/main/java/com/safeticket/event/EventRepository.java
+++ b/src/main/java/com/safeticket/event/EventRepository.java
@@ -1,0 +1,10 @@
+package com.safeticket.event;
+
+import com.safeticket.event.entity.Event;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface EventRepository extends JpaRepository<Event, Long> {
+
+}

--- a/src/main/java/com/safeticket/event/dto/EventResponse.java
+++ b/src/main/java/com/safeticket/event/dto/EventResponse.java
@@ -1,0 +1,36 @@
+package com.safeticket.event.dto;
+
+import com.safeticket.event.entity.Event;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Builder
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class EventResponse {
+    private Long id;
+    private String name;
+    private String description;
+    private Integer durationMinutes;
+    private String status;
+
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+
+    public static EventResponse of(Event event) {
+        return EventResponse.builder()
+                .id(event.getId())
+                .name(event.getName())
+                .description(event.getDescription())
+                .durationMinutes(event.getDurationMinutes())
+                .status(event.getStatus().getStatus())
+                .createdAt(event.getCreatedAt())
+                .updatedAt(event.getUpdatedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/safeticket/event/dto/EventResponse.java
+++ b/src/main/java/com/safeticket/event/dto/EventResponse.java
@@ -1,12 +1,15 @@
 package com.safeticket.event.dto;
 
 import com.safeticket.event.entity.Event;
+import com.safeticket.showtime.dto.ShowtimeResponse;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.List;
 
 @Builder
 @Getter
@@ -18,6 +21,7 @@ public class EventResponse {
     private String description;
     private Integer durationMinutes;
     private String status;
+    private List<ShowtimeResponse> showtimes;
 
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
@@ -29,6 +33,7 @@ public class EventResponse {
                 .description(event.getDescription())
                 .durationMinutes(event.getDurationMinutes())
                 .status(event.getStatus().getStatus())
+                .showtimes(event.getShowtimes() == null ? null : ShowtimeResponse.ofList(event.getShowtimes()))
                 .createdAt(event.getCreatedAt())
                 .updatedAt(event.getUpdatedAt())
                 .build();

--- a/src/main/java/com/safeticket/event/entity/Event.java
+++ b/src/main/java/com/safeticket/event/entity/Event.java
@@ -1,6 +1,8 @@
 package com.safeticket.event.entity;
 
 import com.safeticket.common.util.BaseTimeEntity;
+import com.safeticket.showtime.entity.Showtime;
+import com.safeticket.venue.entity.Venue;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -8,39 +10,42 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Event extends BaseTimeEntity {
     @Id
-    @GeneratedValue
-    @Column(name = "EVENT_ID")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "eventId")
     private Long id;
 
+    @Column(columnDefinition = "VARCHAR(255) COMMENT '이벤트명'")
     private String name;
-    private String date_time;
-    private String location;
+
+    @Column(columnDefinition = "VARCHAR(255) COMMENT '이벤트 설명'")
+    private String description;
+
+    @Column(columnDefinition = "INT COMMENT '공연시간'")
+    private Integer durationMinutes;
+
+    @OneToMany(mappedBy = "event", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Showtime> showtimes = new ArrayList<>();
 
     @Enumerated(EnumType.STRING)
     private EventStatus status;
 
     @Builder
-    public Event(String name, String date_time, String location, EventStatus status) {
-        this.name = name;
-        this.date_time = date_time;
-        this.location = location;
-        this.status = status;
-    }
-
-    @Builder
-    public Event(Long id, String name, String date_time, String location, EventStatus status, LocalDateTime created_at, LocalDateTime updated_at) {
+    public Event(Long id, String name, String description, Integer durationMinutes, List<Showtime> showtimes, EventStatus status, LocalDateTime createdAt, LocalDateTime updatedAt) {
         this.id = id;
         this.name = name;
-        this.date_time = date_time;
-        this.location = location;
+        this.description = description;
+        this.durationMinutes = durationMinutes;
+        this.showtimes = showtimes;
         this.status = status;
-        this.created_at = created_at;
-        this.updated_at = updated_at;
+        this.createdAt = createdAt;
+        this.updatedAt = updatedAt;
     }
 }

--- a/src/main/java/com/safeticket/event/entity/Event.java
+++ b/src/main/java/com/safeticket/event/entity/Event.java
@@ -1,0 +1,46 @@
+package com.safeticket.event.entity;
+
+import com.safeticket.common.util.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Event extends BaseTimeEntity {
+    @Id
+    @GeneratedValue
+    @Column(name = "EVENT_ID")
+    private Long id;
+
+    private String name;
+    private String date_time;
+    private String location;
+
+    @Enumerated(EnumType.STRING)
+    private EventStatus status;
+
+    @Builder
+    public Event(String name, String date_time, String location, EventStatus status) {
+        this.name = name;
+        this.date_time = date_time;
+        this.location = location;
+        this.status = status;
+    }
+
+    @Builder
+    public Event(Long id, String name, String date_time, String location, EventStatus status, LocalDateTime created_at, LocalDateTime updated_at) {
+        this.id = id;
+        this.name = name;
+        this.date_time = date_time;
+        this.location = location;
+        this.status = status;
+        this.created_at = created_at;
+        this.updated_at = updated_at;
+    }
+}

--- a/src/main/java/com/safeticket/event/entity/EventStatus.java
+++ b/src/main/java/com/safeticket/event/entity/EventStatus.java
@@ -1,0 +1,17 @@
+package com.safeticket.event.entity;
+
+import lombok.Getter;
+
+@Getter
+public enum EventStatus {
+    DRAFT("초안"),
+    PUBLISHED("게시"),
+    CANCELLED("취소");
+
+    private final String status;
+
+    EventStatus(String status) {
+        this.status = status;
+    }
+
+}

--- a/src/main/java/com/safeticket/event/exception/EventNotFoundException.java
+++ b/src/main/java/com/safeticket/event/exception/EventNotFoundException.java
@@ -1,0 +1,7 @@
+package com.safeticket.event.exception;
+
+public class EventNotFoundException extends RuntimeException {
+    public EventNotFoundException(Long eventId) {
+        super(("이벤트 ID " + eventId + "를 찾을 수 없습니다."));
+    }
+}

--- a/src/main/java/com/safeticket/event/service/EventService.java
+++ b/src/main/java/com/safeticket/event/service/EventService.java
@@ -1,0 +1,10 @@
+package com.safeticket.event.service;
+
+import com.safeticket.event.entity.Event;
+
+import java.util.List;
+
+public interface EventService {
+    Event getEventById(Long id);
+    List<Event> getAllEvents();
+}

--- a/src/main/java/com/safeticket/event/service/EventServiceImpl.java
+++ b/src/main/java/com/safeticket/event/service/EventServiceImpl.java
@@ -2,6 +2,7 @@ package com.safeticket.event.service;
 
 import com.safeticket.event.entity.Event;
 import com.safeticket.event.EventRepository;
+import com.safeticket.event.exception.EventNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -15,7 +16,8 @@ public class EventServiceImpl implements EventService {
 
     @Override
     public Event getEventById(Long id) {
-        return eventRepository.findById(id).orElse(null);
+        return eventRepository.findById(id)
+                .orElseThrow(() -> new EventNotFoundException(id));
     }
 
     @Override

--- a/src/main/java/com/safeticket/event/service/EventServiceImpl.java
+++ b/src/main/java/com/safeticket/event/service/EventServiceImpl.java
@@ -4,7 +4,9 @@ import com.safeticket.event.entity.Event;
 import com.safeticket.event.EventRepository;
 import com.safeticket.event.exception.EventNotFoundException;
 import lombok.RequiredArgsConstructor;
+import org.hibernate.Hibernate;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
@@ -15,6 +17,7 @@ public class EventServiceImpl implements EventService {
     private final EventRepository eventRepository;
 
     @Override
+    @Transactional(readOnly = true)
     public Event getEventById(Long id) {
         return eventRepository.findById(id)
                 .orElseThrow(() -> new EventNotFoundException(id));
@@ -23,5 +26,10 @@ public class EventServiceImpl implements EventService {
     @Override
     public List<Event> getAllEvents() {
         return eventRepository.findAll();
+    }
+
+    public Event getEventByIdWithShowtimes(Long id) {
+        return eventRepository.findByIdWithShowtimes(id)
+                .orElseThrow(() -> new EventNotFoundException(id));
     }
 }

--- a/src/main/java/com/safeticket/event/service/EventServiceImpl.java
+++ b/src/main/java/com/safeticket/event/service/EventServiceImpl.java
@@ -1,0 +1,25 @@
+package com.safeticket.event.service;
+
+import com.safeticket.event.entity.Event;
+import com.safeticket.event.EventRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class EventServiceImpl implements EventService {
+
+    private final EventRepository eventRepository;
+
+    @Override
+    public Event getEventById(Long id) {
+        return eventRepository.findById(id).orElse(null);
+    }
+
+    @Override
+    public List<Event> getAllEvents() {
+        return eventRepository.findAll();
+    }
+}

--- a/src/main/java/com/safeticket/showtime/dto/ShowtimeResponse.java
+++ b/src/main/java/com/safeticket/showtime/dto/ShowtimeResponse.java
@@ -1,0 +1,55 @@
+package com.safeticket.showtime.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.safeticket.event.entity.Event;
+import com.safeticket.showtime.entity.Showtime;
+import com.safeticket.venue.entity.Venue;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Builder
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonIgnoreProperties({"hibernateLazyInitializer", "handler"})
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+public class ShowtimeResponse {
+    private Long id;
+    private LocalDateTime startTime;
+    private LocalDateTime endTime;
+    private Event event;
+    private Venue venue;
+
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+
+    public static ShowtimeResponse of(Showtime showtime) {
+        if (showtime == null) {
+            return null;
+        }
+        return ShowtimeResponse.builder()
+                .id(showtime.getId())
+                .startTime(showtime.getStartTime())
+                .endTime(showtime.getEndTime())
+                .event(showtime.getEvent())
+                .venue(showtime.getVenue())
+                .createdAt(showtime.getCreatedAt())
+                .updatedAt(showtime.getUpdatedAt())
+                .build();
+    }
+
+    public static List<ShowtimeResponse> ofList(List<Showtime> showtimes) {
+        return (showtimes == null) ? Collections.emptyList()
+                : showtimes.stream().map(ShowtimeResponse::of).collect(Collectors.toList());
+    }
+
+
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,12 @@
 spring.application.name=safeticket
+
+spring.datasource.url=jdbc:mysql://localhost:3306/safeticket_db
+spring.datasource.username=root
+spring.datasource.password=
+spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
+
+spring.jpa.hibernate.ddl-auto=update
+spring.jpa.show-sql=true
+spring.jpa.properties.hibernate.format_sql=true
+spring.jpa.properties.hibernate.use_sql_comments=true
+spring.jpa.database-platform=org.hibernate.dialect.MySQLDialect

--- a/src/test/java/com/safeticket/event/EventServiceImplTest.java
+++ b/src/test/java/com/safeticket/event/EventServiceImplTest.java
@@ -1,0 +1,55 @@
+package com.safeticket.event;
+
+import com.safeticket.event.dto.EventResponse;
+import com.safeticket.event.entity.Event;
+import com.safeticket.event.entity.EventStatus;
+import com.safeticket.event.service.EventServiceImpl;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class EventServiceImplTest {
+
+    @Mock
+    private EventRepository eventRepository;
+
+    @InjectMocks
+    private EventServiceImpl eventService;
+
+    Event event;
+
+    EventResponse eventResponse;
+
+    @BeforeEach
+    void setUp() {
+        event = Event.builder()
+                .name("이벤트명")
+                .date_time("2023-10-10T10:00:00")
+                .location("장소")
+                .status(EventStatus.PUBLISHED)
+                .build();
+    }
+
+    @Test
+    public void getEventById_shouldReturnEvent_whenEventExist() {
+        // given
+        when(eventRepository.findById(1L)).thenReturn(Optional.of(event));
+
+        // when
+        Event result = eventService.getEventById(1L);
+
+        // then
+        assertThat(result).isEqualTo(event);
+    }
+}


### PR DESCRIPTION
📌 변경 사항

- GlobalExceptionHandler 추가
- BaseTimeEntity 추가

🤔 고민한 점

- 애플리케이션 예외를 한곳에서 관리하기 위해서 GlobalExceptionHandler를 생성했습니다.
- 엔티티에서 공통으로 사용하는 createdAt, updatedAt 필드의 중복을 BaseTimeEntity로 관리하도록 추출했습니다.