### PR TITLE
feat: 공통 GlobalExceptionHandler와 BaseTimeEntity 추가

### DIFF
--- a/src/main/java/com/safeticket/SafeTicketApplication.java
+++ b/src/main/java/com/safeticket/SafeTicketApplication.java
@@ -2,8 +2,10 @@ package com.safeticket;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableJpaAuditing
 public class SafeTicketApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/com/safeticket/common/advice/GlobalExceptionHandler.java
+++ b/src/main/java/com/safeticket/common/advice/GlobalExceptionHandler.java
@@ -1,0 +1,25 @@
+package com.safeticket.common.advice;
+
+import com.safeticket.event.exception.EventNotFoundException;
+import com.safeticket.showtime.exception.ShowtimeNotFoundException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(EventNotFoundException.class)
+    @ResponseStatus(HttpStatus.NOT_FOUND)
+    public ResponseEntity<String> handleEventNotFoundException(EventNotFoundException ex) {
+        return new ResponseEntity<>(ex.getMessage(), HttpStatus.NOT_FOUND);
+    }
+
+    @ExceptionHandler(ShowtimeNotFoundException.class)
+    @ResponseStatus(HttpStatus.NOT_FOUND)
+    public ResponseEntity<String> handleShowtimeNotFoundException(ShowtimeNotFoundException ex) {
+        return new ResponseEntity<>(ex.getMessage(), HttpStatus.NOT_FOUND);
+    }
+}

--- a/src/main/java/com/safeticket/common/util/BaseTimeEntity.java
+++ b/src/main/java/com/safeticket/common/util/BaseTimeEntity.java
@@ -1,0 +1,23 @@
+package com.safeticket.common.util;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseTimeEntity {
+    @CreatedDate
+    @Column(nullable = false, updatable = false)
+    protected LocalDateTime createdAt;
+
+    @LastModifiedDate
+    protected LocalDateTime updatedAt;
+}


### PR DESCRIPTION
📌 변경 사항

- GlobalExceptionHandler 추가
- BaseTimeEntity 추가

🤔 고민한 점

- 애플리케이션 예외를 한곳에서 관리하기 위해서 GlobalExceptionHandler를 생성했습니다.
- 엔티티에서 공통으로 사용하는 createdAt, updatedAt 필드의 중복을 BaseTimeEntity로 관리하도록 추출했습니다.