### PR TITLE
feat: EHcache 설정 파일 추가

### DIFF
--- a/src/main/java/com/safeticket/common/cache/CacheConfig.java
+++ b/src/main/java/com/safeticket/common/cache/CacheConfig.java
@@ -1,4 +1,4 @@
-package com.safeticket.common.config;
+package com.safeticket.common.cache;
 
 import org.ehcache.jsr107.EhcacheCachingProvider;
 import org.springframework.cache.annotation.EnableCaching;

--- a/src/main/java/com/safeticket/common/config/CacheConfig.java
+++ b/src/main/java/com/safeticket/common/config/CacheConfig.java
@@ -1,16 +1,27 @@
 package com.safeticket.common.config;
 
+import org.ehcache.jsr107.EhcacheCachingProvider;
 import org.springframework.cache.annotation.EnableCaching;
-import org.springframework.cache.concurrent.ConcurrentMapCacheManager;
+import org.springframework.cache.jcache.JCacheCacheManager;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+
+import javax.cache.CacheManager;
+import javax.cache.Caching;
+import javax.cache.spi.CachingProvider;
+import java.net.URISyntaxException;
+import java.util.Objects;
 
 @Configuration
 @EnableCaching
 public class CacheConfig {
 
     @Bean
-    public ConcurrentMapCacheManager cacheManager() {
-        return new ConcurrentMapCacheManager("availableTickets");
+    public JCacheCacheManager cacheManager() throws URISyntaxException {
+        CachingProvider provider = Caching.getCachingProvider(EhcacheCachingProvider.class.getName());
+        CacheManager cacheManager = provider.getCacheManager(
+                Objects.requireNonNull(getClass().getResource("/ehcache.xml")).toURI(),
+                provider.getDefaultClassLoader());
+        return new JCacheCacheManager(cacheManager);
     }
 }

--- a/src/main/java/com/safeticket/common/metrics/MetricsAspect.java
+++ b/src/main/java/com/safeticket/common/metrics/MetricsAspect.java
@@ -1,0 +1,24 @@
+package com.safeticket.common.metrics;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import lombok.RequiredArgsConstructor;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.springframework.stereotype.Component;
+
+@Aspect
+@Component
+@RequiredArgsConstructor
+public class MetricsAspect {
+
+    private final MeterRegistry meterRegistry;
+
+    @Around("@annotation(trackMetrics)")
+    public Object incrementCounter(ProceedingJoinPoint joinPoint, TrackMetrics trackMetrics) throws Throwable {
+        Counter counter = meterRegistry.counter(trackMetrics.value());
+        counter.increment();
+        return joinPoint.proceed();
+    }
+}

--- a/src/main/java/com/safeticket/common/metrics/MetricsConfig.java
+++ b/src/main/java/com/safeticket/common/metrics/MetricsConfig.java
@@ -1,0 +1,24 @@
+package com.safeticket.common.metrics;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class MetricsConfig {
+
+    @Bean
+    public Counter availableTicketsCounter(MeterRegistry meterRegistry) {
+        return Counter.builder("available_tickets_requests_total")
+                .description("Total available tickets requests")
+                .register(meterRegistry);
+    }
+
+    @Bean
+    public Counter reservationCounter(MeterRegistry meterRegistry) {
+        return Counter.builder("reservation_requests_total")
+                .description("Total reservation requests")
+                .register(meterRegistry);
+    }
+}

--- a/src/main/java/com/safeticket/common/metrics/TrackMetrics.java
+++ b/src/main/java/com/safeticket/common/metrics/TrackMetrics.java
@@ -1,0 +1,12 @@
+package com.safeticket.common.metrics;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface TrackMetrics {
+    String value();
+}

--- a/src/main/java/com/safeticket/ticket/controller/TicketController.java
+++ b/src/main/java/com/safeticket/ticket/controller/TicketController.java
@@ -1,5 +1,6 @@
 package com.safeticket.ticket.controller;
 
+import com.safeticket.common.metrics.TrackMetrics;
 import com.safeticket.ticket.dto.AvailableTicketsDTO;
 import com.safeticket.ticket.dto.TicketDTO;
 import com.safeticket.ticket.service.TicketService;
@@ -9,21 +10,22 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
 @RequestMapping(value = "/tickets", produces = MediaType.APPLICATION_JSON_VALUE)
 public class TicketController {
 
-    final TicketService ticketService;
+    private final TicketService ticketService;
 
     @Cacheable("availableTickets")
+    @TrackMetrics("available_tickets_requests_total")
     @GetMapping("/available/{showtimeId}")
     public ResponseEntity<AvailableTicketsDTO> getAvailableTickets(@PathVariable Long showtimeId) {
         return ResponseEntity.ok(ticketService.getAvailableTickets(showtimeId));
     }
 
+    @TrackMetrics("reservation_requests_total")
     @PutMapping("/reservations")
     public ResponseEntity<Void> reserveTickets(@RequestBody TicketDTO ticketDTO) {
         ticketService.reserveTickets(ticketDTO);

--- a/src/main/resources/ehcache.xml
+++ b/src/main/resources/ehcache.xml
@@ -1,0 +1,14 @@
+<config xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance'
+        xmlns='http://www.ehcache.org/v3'
+        xsi:schemaLocation="http://www.ehcache.org/v3 http://www.ehcache.org/schema/ehcache-core.xsd">
+
+    <cache alias="availableTickets">
+        <expiry>
+            <ttl unit="seconds">10</ttl>
+        </expiry>
+        <resources>
+            <heap unit="entries">10</heap>
+        </resources>
+    </cache>
+
+</config>


### PR DESCRIPTION
📌 변경 사항

- CacheConfig 파일 Ehcache 설정 코드 수정
- ehcache.xml 파일 추가

🤔 고민한 점

- 업데이트시 @Cacheable 를 어떻게 처리할지 몇 가지 방법을 찾아 봤습니다. 
- 1. (제외) @CacheEvict는 update 할때마다 캐시를 비우는 방법인데 update가 특정 시점에 자주 발생하는 티켓예매에서는 부적합하다고 판단하여 제외했습니다.
- 2. (채택) TTL을 사용하는 방법으로 EHcache를 선택했습니다. 서비스 특징에 따라 데이터 일관성을 즉시 반영할 필요는 없다고 판단하였기 때문입니다. 또한, 예매처리 비지니스 로직에서 한번더 티켓 상태를 검증하기 때문에 안전하다고 생각했습니다.
- 3. (보류) 분산 서버를 사용하는 상황에서는 TTL(만료시간 설정)을 지원하는 Redis를 고려해볼 수 있다고 생각했습니다. 
