### PR TITLE
feat: 개별 api 메트릭 기능 추가

### DIFF
--- a/src/main/java/com/safeticket/common/cache/CacheConfig.java
+++ b/src/main/java/com/safeticket/common/cache/CacheConfig.java
@@ -1,4 +1,4 @@
-package com.safeticket.common.config;
+package com.safeticket.common.cache;
 
 import org.ehcache.jsr107.EhcacheCachingProvider;
 import org.springframework.cache.annotation.EnableCaching;

--- a/src/main/java/com/safeticket/common/metrics/MetricsAspect.java
+++ b/src/main/java/com/safeticket/common/metrics/MetricsAspect.java
@@ -1,0 +1,24 @@
+package com.safeticket.common.metrics;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import lombok.RequiredArgsConstructor;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.springframework.stereotype.Component;
+
+@Aspect
+@Component
+@RequiredArgsConstructor
+public class MetricsAspect {
+
+    private final MeterRegistry meterRegistry;
+
+    @Around("@annotation(trackMetrics)")
+    public Object incrementCounter(ProceedingJoinPoint joinPoint, TrackMetrics trackMetrics) throws Throwable {
+        Counter counter = meterRegistry.counter(trackMetrics.value());
+        counter.increment();
+        return joinPoint.proceed();
+    }
+}

--- a/src/main/java/com/safeticket/common/metrics/MetricsConfig.java
+++ b/src/main/java/com/safeticket/common/metrics/MetricsConfig.java
@@ -1,0 +1,24 @@
+package com.safeticket.common.metrics;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class MetricsConfig {
+
+    @Bean
+    public Counter availableTicketsCounter(MeterRegistry meterRegistry) {
+        return Counter.builder("available_tickets_requests_total")
+                .description("Total available tickets requests")
+                .register(meterRegistry);
+    }
+
+    @Bean
+    public Counter reservationCounter(MeterRegistry meterRegistry) {
+        return Counter.builder("reservation_requests_total")
+                .description("Total reservation requests")
+                .register(meterRegistry);
+    }
+}

--- a/src/main/java/com/safeticket/common/metrics/TrackMetrics.java
+++ b/src/main/java/com/safeticket/common/metrics/TrackMetrics.java
@@ -1,0 +1,12 @@
+package com.safeticket.common.metrics;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface TrackMetrics {
+    String value();
+}

--- a/src/main/java/com/safeticket/ticket/controller/TicketController.java
+++ b/src/main/java/com/safeticket/ticket/controller/TicketController.java
@@ -1,5 +1,6 @@
 package com.safeticket.ticket.controller;
 
+import com.safeticket.common.metrics.TrackMetrics;
 import com.safeticket.ticket.dto.AvailableTicketsDTO;
 import com.safeticket.ticket.dto.TicketDTO;
 import com.safeticket.ticket.service.TicketService;
@@ -9,21 +10,22 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
 @RequestMapping(value = "/tickets", produces = MediaType.APPLICATION_JSON_VALUE)
 public class TicketController {
 
-    final TicketService ticketService;
+    private final TicketService ticketService;
 
     @Cacheable("availableTickets")
+    @TrackMetrics("available_tickets_requests_total")
     @GetMapping("/available/{showtimeId}")
     public ResponseEntity<AvailableTicketsDTO> getAvailableTickets(@PathVariable Long showtimeId) {
         return ResponseEntity.ok(ticketService.getAvailableTickets(showtimeId));
     }
 
+    @TrackMetrics("reservation_requests_total")
     @PutMapping("/reservations")
     public ResponseEntity<Void> reserveTickets(@RequestBody TicketDTO ticketDTO) {
         ticketService.reserveTickets(ticketDTO);


### PR DESCRIPTION
📌 변경 사항

- TicketController의 api 에 메트릭 어노테이션 추가
- TrackMetrics 어노테이션 추가
- Metrics 설정 파일 추가, Metrics Aspect 파일 추가

🤔 고민한 점

- Controller 내부 로직에 메트릭 추가 기능을 구현하고 단일책임원칙을 준수하기위해 Metrics 관련 모듈을 새로 생성하였습니다.

🐛 문제점

- 그라파나에서 api 요청 카운트가 그래프로 보이지만 `@Cacheable`에서 HIT 가 발생하는 경우에 메트릭의 정확한 집계가 이루어지지 않는 문제가 있습니다. 현재 이 이슈를 해결하기 위해 2가지 방법을 생각했습니다.
1. Cache 관련 클래스를 커스터마이징을하여 HIT 하는 경우에 메트릭 카운트를 증가하는 방법
2. Controller 레벨이 아닌 더 상위 Layer에서 메트릭을 집계하는 방법