### PR TITLE
feat: Terraform을 사용한 EC2 인스턴스 생성 추가

### DIFF
--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -1,0 +1,31 @@
+provider "aws" {
+  region = "ap-northeast-2" # 서울
+}
+
+variable "instances" {
+  type = list(object({
+    name          = string
+    instance_type = string
+    ami           = string
+  }))
+  default = [
+    { name = "spring-server", instance_type = "t2.micro", ami = "ami-0891aeb92f786d7a2" },
+    { name = "monitoring-server", instance_type = "t2.micro", ami = "ami-0891aeb92f786d7a2" },
+    { name = "ngrinder-server", instance_type = "t2.micro", ami = "ami-0891aeb92f786d7a2" }
+  ]
+}
+
+resource "aws_instance" "servers" {
+  count         = length(var.instances)
+  ami           = var.instances[count.index].ami
+  instance_type = var.instances[count.index].instance_type
+
+  tags = {
+    Name = var.instances[count.index].name
+  }
+}
+
+output "ec2_instances" {
+  value = aws_instance.servers[*].public_ip
+}
+

--- a/infrastructure/outputs.tf
+++ b/infrastructure/outputs.tf
@@ -1,0 +1,10 @@
+output "public_ips" {
+  description = "EC2 인스턴스들의 Public IP 목록"
+  value       = aws_instance.servers[*].public_ip
+}
+
+output "instance_ids" {
+  description = "EC2 인스턴스들의 ID"
+  value       = aws_instance.servers[*].id
+}
+

--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -1,0 +1,10 @@
+variable "region" {
+  description = "AWS 리전"
+  default     = "ap-northeast-2"
+}
+
+variable "instance_type" {
+  description = "EC2 인스턴스 타입"
+  default     = "t2.micro"
+}
+


### PR DESCRIPTION
📌 변경 사항
- 테라폼 구성 파일 추가 (main.tf, outputs.tf, variables.tf)

🤔 고민한 점

- 클라우드 비용 절감을 위해 IaC(Terraform)를 사용하여 서버 관리 기능을 추가하였습니다. EC2 인스턴스 3개(모니터링, nGrinder, Spring 서버)를 설정하였습니다.