### PR TITLE
feat: GitHub Actions를 사용한 CI/CD 설정 추가

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,161 @@
+name: EC2 배포(Ticket, Monitoring)
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  get-ec2-info:
+    runs-on: ubuntu-latest
+    outputs:
+      TICKET_SERVER_PUBLIC_IP: ${{ steps.ticket-server-ec2-info.outputs.TICKET_SERVER_PUBLIC_IP }}
+      MONITORING_PUBLIC_IP: ${{ steps.monitoring-server-ec2-info.outputs.MONITORING_PUBLIC_IP }}
+
+    steps:
+      - name: AWS 자격 증명 세팅
+        uses: aws-actions/configure-aws-credentials@v2
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ap-northeast-2
+
+      - name: Ticket 서버 EC2 Public IP 가져오기
+        id: ticket-server-ec2-info
+        run: |
+          TICKET_SERVER_PUBLIC_IP=$(aws ec2 describe-instances \
+            --filters 'Name=tag:Name,Values=spring-server' 'Name=instance-state-name,Values=running' \
+            --query 'Reservations[0].Instances[0].PublicIpAddress' \
+            --output text)
+          echo "TICKET_SERVER_PUBLIC_IP=${TICKET_SERVER_PUBLIC_IP}"
+          echo "TICKET_SERVER_PUBLIC_IP=${TICKET_SERVER_PUBLIC_IP}" >> $GITHUB_ENV
+          echo "::set-output name=TICKET_SERVER_PUBLIC_IP::${TICKET_SERVER_PUBLIC_IP}"
+      - name: Monitoring 서버 EC2 Public IP 가져오기
+        id: monitoring-server-ec2-info
+        run: |
+          MONITORING_PUBLIC_IP=$(aws ec2 describe-instances \
+            --filters "Name=tag:Name,Values=monitoring-server" "Name=instance-state-name,Values=running" \
+            --query 'Reservations[0].Instances[0].PublicIpAddress' \
+            --output text)
+          echo "MONITORING_PUBLIC_IP=${MONITORING_PUBLIC_IP}"
+          echo "MONITORING_PUBLIC_IP=${MONITORING_PUBLIC_IP}" >> $GITHUB_ENV
+          echo "::set-output name=MONITORING_PUBLIC_IP::${MONITORING_PUBLIC_IP}"
+  build-spring:
+    runs-on: ubuntu-latest
+    outputs:
+      TAG: ${{ steps.get-latest-tag.outputs.TAG }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          path: ticket-server
+
+      - name: JDK 17 설치
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'adopt'
+
+      - name: Gradle 빌드
+        run: ./gradlew build
+        working-directory: ticket-server
+
+      - name: 최신 Git 태그 가져오기
+        id: get-latest-tag
+        working-directory: ticket-server
+        run: |
+          git fetch --tags --force
+          TAG=$(git tag --sort=-creatordate | head -n 1)
+          echo "TAG=$TAG" >> $GITHUB_ENV
+          echo "::set-output name=TAG::${TAG}"
+      - name: Docker 이미지 빌드
+        env:
+          TAG: ${{ env.TAG }}
+        run: docker build -t boosterko/ticket-app:$TAG .
+        working-directory: ticket-server
+
+      - name: Docker Hub 로그인
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_PASSWORD }}
+
+      - name: Docker Hub 이미지 푸시
+        env:
+          TAG: ${{ env.TAG }}
+        run: docker push boosterko/ticket-app:$TAG
+
+  deploy-spring:
+    runs-on: ubuntu-latest
+    needs: [build-spring, get-ec2-info]
+
+    steps:
+      - name: 환경 변수 설정
+        run: |
+          echo "TICKET_SERVER_PUBLIC_IP=${{ needs.get-ec2-info.outputs.TICKET_SERVER_PUBLIC_IP }}" >> $GITHUB_ENV
+          echo "TAG=${{ needs.build-spring.outputs.TAG }}" >> $GITHUB_ENV
+      - name: 티켓 서버 EC2에 배포
+        uses: appleboy/ssh-action@v0.1.3
+        with:
+          host: ${{ env.TICKET_SERVER_PUBLIC_IP }}
+          username: ${{ secrets.SPRING_EC2_USER }}
+          key: ${{ secrets.SPRING_EC2_SSH_KEY }}
+          port: 22
+          script: |
+            sudo yum update -y
+            sudo yum install -y docker
+            sudo systemctl start docker
+            sudo docker pull boosterko/ticket-app:${{ env.TAG }}
+            sudo docker stop ticket-app || true
+            sudo docker rm ticket-app || true
+            sudo docker run -d -p 8080:8080 --name ticket-app \
+              -e DB_URL=${{ secrets.DB_URL }} \
+              -e DB_USERNAME=${{ secrets.DB_USERNAME }} \
+              -e DB_PASSWORD=${{ secrets.DB_PASSWORD }} \
+              boosterko/ticket-app:${{ env.TAG }}
+  deploy-monitoring:
+    runs-on: ubuntu-latest
+    needs: get-ec2-info
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: 환경 변수 설정
+        run: echo "MONITORING_PUBLIC_IP=${{ needs.get-ec2-info.outputs.MONITORING_PUBLIC_IP }}" >> $GITHUB_ENV
+
+      - name: AWS EC2로 모니터링 파일 전송
+        uses: appleboy/scp-action@master
+        with:
+          host: ${{ env.MONITORING_PUBLIC_IP }}
+          username: ${{ secrets.SPRING_EC2_USER }}
+          key: ${{ secrets.SPRING_EC2_SSH_KEY }}
+          port: 22
+          source: "monitoring/*.yml"
+          target: "/home/${{ secrets.SPRING_EC2_USER }}/"
+          overwrite: true
+
+      - name: 모니터링 서버 EC2에 배포
+        uses: appleboy/ssh-action@v1.0.3
+        with:
+          host: ${{ env.MONITORING_PUBLIC_IP }}
+          username: ${{ secrets.SPRING_EC2_USER }}
+          key: ${{ secrets.SPRING_EC2_SSH_KEY }}
+          port: 22
+          script: |
+            sudo curl -L "https://github.com/docker/compose/releases/latest/download/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
+            sudo chmod +x /usr/local/bin/docker-compose
+            sudo rm -f /usr/bin/docker-compose
+            sudo ln -s /usr/local/bin/docker-compose /usr/bin/docker-compose
+            sudo yum update -y
+            sudo yum install -y docker
+            sudo systemctl start docker
+            sudo usermod -aG docker ${{ secrets.SPRING_EC2_USER }}
+            sudo newgrp docker
+            cd /home/${{ secrets.SPRING_EC2_USER }}/monitoring
+            export GRAFANA_PASSWORD=${{ secrets.GRAFANA_PASSWORD }}
+            export SLACK_API_URL=${{ secrets.SLACK_API_URL }}
+            sudo docker-compose pull
+            sudo docker-compose down
+            sudo docker-compose up -d

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -40,6 +40,7 @@ jobs:
           echo "MONITORING_PUBLIC_IP=${MONITORING_PUBLIC_IP}"
           echo "MONITORING_PUBLIC_IP=${MONITORING_PUBLIC_IP}" >> $GITHUB_ENV
           echo "::set-output name=MONITORING_PUBLIC_IP::${MONITORING_PUBLIC_IP}"
+
   build-spring:
     runs-on: ubuntu-latest
     outputs:
@@ -114,6 +115,7 @@ jobs:
               -e DB_USERNAME=${{ secrets.DB_USERNAME }} \
               -e DB_PASSWORD=${{ secrets.DB_PASSWORD }} \
               boosterko/ticket-app:${{ env.TAG }}
+
   deploy-monitoring:
     runs-on: ubuntu-latest
     needs: get-ec2-info

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM openjdk:17-slim
+
+WORKDIR /app
+
+COPY build/libs/ticket-0.0.1-SNAPSHOT.jar app.jar
+
+CMD ["java", "-jar", "app.jar", "--spring.profiles.active=prod"]


### PR DESCRIPTION
📌 변경 사항

- deploy.yml 파일 추가: EC2 배포를 위한 GitHub Actions 워크플로우 설정
- Dockerfile 추가: 애플리케이션을 Docker 컨테이너로 빌드하기 위한 설정

🤔 고민한 점

- Dockerhub에 이미지를 push 할때 TAG를  아래 2가지 방식중 b로 구현했습니다.
  a. 커밋 branch의 hashcode 앞자리 수 사용
  b. github TAG (명확하여 식별하기 편하고, 특정 버전으로 쉽게 돌아가기 좋습니다.)
  