### PR TITLE
feat: feat: 결제(주문) 관련 Controller, Service, Entity, 단위테스트 코드 추가

### DIFF
--- a/order/src/main/java/com/safeticket/common/advice/GlobalExceptionHandler.java
+++ b/order/src/main/java/com/safeticket/common/advice/GlobalExceptionHandler.java
@@ -1,7 +1,10 @@
 package com.safeticket.common.advice;
 
 import com.safeticket.event.exception.EventNotFoundException;
+import com.safeticket.order.exception.OrderAlreadyInProgressException;
+import com.safeticket.order.exception.OrderCreationLockExpiredException;
 import com.safeticket.order.exception.OrderNotFoundException;
+import com.safeticket.order.exception.PaymentProcessingException;
 import com.safeticket.showtime.exception.ShowtimeNotFoundException;
 import com.safeticket.ticket.exception.TicketsNotAvailableException;
 import org.springframework.http.HttpStatus;
@@ -36,4 +39,23 @@ public class GlobalExceptionHandler {
     public ResponseEntity<String> handleOrderNotFoundException(OrderNotFoundException ex) {
         return new ResponseEntity<>(ex.getMessage(), HttpStatus.OK);
     }
+
+    @ExceptionHandler(PaymentProcessingException.class)
+    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+    public ResponseEntity<String> handlePaymentProcessingException(PaymentProcessingException ex) {
+        return new ResponseEntity<>(ex.getMessage(), HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+
+    @ExceptionHandler(OrderCreationLockExpiredException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public ResponseEntity<String> handleOrderCreationLockExpiredException(OrderCreationLockExpiredException ex) {
+        return new ResponseEntity<>(ex.getMessage(), HttpStatus.BAD_REQUEST);
+    }
+
+    @ExceptionHandler(OrderAlreadyInProgressException.class)
+    @ResponseStatus(HttpStatus.OK)
+    public ResponseEntity<String> handleOrderAlreadyInProgressException(OrderAlreadyInProgressException ex) {
+        return new ResponseEntity<>(ex.getMessage(), HttpStatus.OK);
+    }
+
 }

--- a/order/src/main/java/com/safeticket/common/config/RabbitMQConfig.java
+++ b/order/src/main/java/com/safeticket/common/config/RabbitMQConfig.java
@@ -1,0 +1,31 @@
+package com.safeticket.common.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.springframework.amqp.core.Queue;
+import org.springframework.amqp.rabbit.connection.ConnectionFactory;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.amqp.support.converter.Jackson2JsonMessageConverter;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+
+@Configuration
+public class RabbitMQConfig {
+
+    @Value("${rabbitmq.queue.payment}")
+    private String paymentQueue;
+
+    @Bean
+    public RabbitTemplate rabbitTemplate(ConnectionFactory connectionFactory) {
+        RabbitTemplate rabbitTemplate = new RabbitTemplate(connectionFactory);
+        rabbitTemplate.setMessageConverter(new Jackson2JsonMessageConverter());
+        return rabbitTemplate;
+    }
+
+    @Bean
+    public Queue paymentQueue() {
+        return new Queue(paymentQueue, true);
+    }
+}

--- a/order/src/main/java/com/safeticket/order/controller/OrderController.java
+++ b/order/src/main/java/com/safeticket/order/controller/OrderController.java
@@ -1,0 +1,25 @@
+package com.safeticket.order.controller;
+
+import com.safeticket.order.dto.OrderDTO;
+import com.safeticket.order.service.OrderService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/orders")
+public class OrderController {
+
+    private final OrderService orderService;
+
+    @PostMapping
+    public ResponseEntity<OrderDTO> createOrder(@RequestBody OrderDTO request) {
+        return new ResponseEntity<>(orderService.createOrder(request), HttpStatus.CREATED);
+    }
+}

--- a/order/src/main/java/com/safeticket/order/controller/OrderController.java
+++ b/order/src/main/java/com/safeticket/order/controller/OrderController.java
@@ -13,7 +13,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/orders")
+@RequestMapping("/orders")
 public class OrderController {
 
     private final OrderService orderService;

--- a/order/src/main/java/com/safeticket/order/dto/OrderDTO.java
+++ b/order/src/main/java/com/safeticket/order/dto/OrderDTO.java
@@ -1,0 +1,23 @@
+package com.safeticket.order.dto;
+
+import com.safeticket.order.entity.Order;
+import com.safeticket.order.entity.OrderTicket;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Builder
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class OrderDTO {
+    private Long orderId;
+    private Long userId;
+    private Integer amount;
+    private List<Long> ticketIds;
+    private String status;
+}

--- a/order/src/main/java/com/safeticket/order/dto/PaymentDTO.java
+++ b/order/src/main/java/com/safeticket/order/dto/PaymentDTO.java
@@ -1,0 +1,18 @@
+package com.safeticket.order.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+
+@Builder
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class PaymentDTO {
+    private Long orderId;
+    private Integer amount;
+    private Long userId;
+    private String status;
+}

--- a/order/src/main/java/com/safeticket/order/entity/Order.java
+++ b/order/src/main/java/com/safeticket/order/entity/Order.java
@@ -1,6 +1,7 @@
 package com.safeticket.order.entity;
 
 import com.esotericsoftware.kryo.serializers.FieldSerializer;
+import com.fasterxml.jackson.annotation.JsonManagedReference;
 import com.safeticket.common.util.BaseTimeEntity;
 import com.safeticket.ticket.entity.Ticket;
 import jakarta.persistence.*;
@@ -9,6 +10,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @Entity
@@ -25,21 +27,20 @@ public class Order extends BaseTimeEntity {
 
     private Integer amount;
 
-    @ElementCollection
-    @CollectionTable(name = "orderTickets", joinColumns = @JoinColumn(name = "orderId"))
-    @Column(name = "ticketId")
-    private List<Long> ticketIds;
+    @OneToMany(mappedBy = "order", cascade = CascadeType.ALL, orphanRemoval = true)
+    @JsonManagedReference
+    private List<OrderTicket> orderTickets = new ArrayList<>();
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private OrderStatus status;
 
     @Builder
-    public Order(Long id, Long userId, Integer amount, List<Long> ticketIds, OrderStatus status) {
+    public Order(Long id, Long userId, Integer amount, List<OrderTicket> orderTickets, OrderStatus status) {
         this.id = id;
         this.userId = userId;
         this.amount = amount;
-        this.ticketIds = ticketIds;
+        this.orderTickets = orderTickets != null ? orderTickets : new ArrayList<>();
         this.status = status;
     }
 

--- a/order/src/main/java/com/safeticket/order/entity/Order.java
+++ b/order/src/main/java/com/safeticket/order/entity/Order.java
@@ -1,9 +1,7 @@
 package com.safeticket.order.entity;
 
-import com.esotericsoftware.kryo.serializers.FieldSerializer;
 import com.fasterxml.jackson.annotation.JsonManagedReference;
 import com.safeticket.common.util.BaseTimeEntity;
-import com.safeticket.ticket.entity.Ticket;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -46,5 +44,9 @@ public class Order extends BaseTimeEntity {
 
     public void updateStatus(OrderStatus status) {
         this.status = status;
+    }
+
+    public boolean isInProgress() {
+        return status.isInProgress();
     }
 }

--- a/order/src/main/java/com/safeticket/order/entity/Order.java
+++ b/order/src/main/java/com/safeticket/order/entity/Order.java
@@ -1,0 +1,49 @@
+package com.safeticket.order.entity;
+
+import com.esotericsoftware.kryo.serializers.FieldSerializer;
+import com.safeticket.common.util.BaseTimeEntity;
+import com.safeticket.ticket.entity.Ticket;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Entity
+@Table(name = "`order`")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Order extends BaseTimeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "orderId")
+    private Long id;
+
+    private Long userId;
+
+    private Integer amount;
+
+    @ElementCollection
+    @CollectionTable(name = "orderTickets", joinColumns = @JoinColumn(name = "orderId"))
+    @Column(name = "ticketId")
+    private List<Long> ticketIds;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private OrderStatus status;
+
+    @Builder
+    public Order(Long id, Long userId, Integer amount, List<Long> ticketIds, OrderStatus status) {
+        this.id = id;
+        this.userId = userId;
+        this.amount = amount;
+        this.ticketIds = ticketIds;
+        this.status = status;
+    }
+
+    public void updateStatus(OrderStatus status) {
+        this.status = status;
+    }
+}

--- a/order/src/main/java/com/safeticket/order/entity/OrderStatus.java
+++ b/order/src/main/java/com/safeticket/order/entity/OrderStatus.java
@@ -1,0 +1,22 @@
+package com.safeticket.order.entity;
+
+import lombok.Getter;
+
+@Getter
+public enum OrderStatus {
+    PENDING("PD", "대기"),
+    PAID("PA", "결제완료"),
+    CANCELLED("CC", "취소");
+
+    private final String code;
+    private final String description;
+
+    OrderStatus(String code, String description) {
+        this.code = code;
+        this.description = description;
+    }
+
+    public boolean isInProgress() {
+        return this == PENDING || this == PAID;
+    }
+}

--- a/order/src/main/java/com/safeticket/order/entity/OrderTicket.java
+++ b/order/src/main/java/com/safeticket/order/entity/OrderTicket.java
@@ -1,0 +1,33 @@
+package com.safeticket.order.entity;
+
+import com.fasterxml.jackson.annotation.JsonBackReference;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "orderTickets")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class OrderTicket {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "orderTicketId")
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "orderId", nullable = false)
+    @JsonBackReference
+    private Order order;
+
+    @Column(name = "ticketId", nullable = false)
+    private Long ticketId;
+
+    @Builder
+    public OrderTicket(Order order, Long ticketId) {
+        this.order = order;
+        this.ticketId = ticketId;
+    }
+}

--- a/order/src/main/java/com/safeticket/order/exception/OrderAlreadyInProgressException.java
+++ b/order/src/main/java/com/safeticket/order/exception/OrderAlreadyInProgressException.java
@@ -1,0 +1,7 @@
+package com.safeticket.order.exception;
+
+public class OrderAlreadyInProgressException extends RuntimeException {
+    public OrderAlreadyInProgressException() {
+        super("이미 처리중인 주문이 있습니다.");
+    }
+}

--- a/order/src/main/java/com/safeticket/order/exception/OrderCreationLockExpiredException.java
+++ b/order/src/main/java/com/safeticket/order/exception/OrderCreationLockExpiredException.java
@@ -1,0 +1,7 @@
+package com.safeticket.order.exception;
+
+public class OrderCreationLockExpiredException extends RuntimeException {
+    public OrderCreationLockExpiredException() {
+        super("티켓 예약 시간이 만료되었습니다.");
+    }
+}

--- a/order/src/main/java/com/safeticket/order/exception/OrderNotFoundException.java
+++ b/order/src/main/java/com/safeticket/order/exception/OrderNotFoundException.java
@@ -1,0 +1,7 @@
+package com.safeticket.order.exception;
+
+public class OrderNotFoundException extends RuntimeException {
+    public OrderNotFoundException(String orderId) {
+        super("주문번호:" + orderId + " 에 해당하는 주문이 없습니다.");
+    }
+}

--- a/order/src/main/java/com/safeticket/order/exception/PaymentProcessingException.java
+++ b/order/src/main/java/com/safeticket/order/exception/PaymentProcessingException.java
@@ -1,0 +1,7 @@
+package com.safeticket.order.exception;
+
+public class PaymentProcessingException extends RuntimeException {
+    public PaymentProcessingException(String orderId) {
+      super("주문번호:" + orderId + " 결제 메세지 처리 중 오류가 발생했습니다.");
+    }
+}

--- a/order/src/main/java/com/safeticket/order/repository/OrderRepository.java
+++ b/order/src/main/java/com/safeticket/order/repository/OrderRepository.java
@@ -1,0 +1,17 @@
+package com.safeticket.order.repository;
+
+import com.safeticket.order.entity.Order;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface OrderRepository extends JpaRepository<Order, Long> {
+
+    @Query("SELECT o FROM Order o JOIN o.orderTickets ot WHERE o.userId = :userId AND ot.ticketId IN :ticketIds ORDER BY o.id DESC")
+    List<Order> findByUserIdAndTicketIds(@Param("userId") Long userId, @Param("ticketIds") List<Long> ticketIds, Pageable pageable);
+}

--- a/order/src/main/java/com/safeticket/order/service/OrderService.java
+++ b/order/src/main/java/com/safeticket/order/service/OrderService.java
@@ -1,0 +1,8 @@
+package com.safeticket.order.service;
+
+import com.safeticket.order.dto.OrderDTO;
+
+public interface OrderService {
+    OrderDTO createOrder(OrderDTO orderDTO);
+    void updateOrderStatus(OrderDTO orderDTO);
+}

--- a/order/src/main/java/com/safeticket/order/service/OrderServiceImpl.java
+++ b/order/src/main/java/com/safeticket/order/service/OrderServiceImpl.java
@@ -1,15 +1,26 @@
 package com.safeticket.order.service;
 
+import com.safeticket.common.util.RedisKeyUtil;
 import com.safeticket.order.dto.OrderDTO;
 import com.safeticket.order.dto.PaymentDTO;
 import com.safeticket.order.entity.Order;
 import com.safeticket.order.entity.OrderStatus;
+import com.safeticket.order.exception.OrderCreationLockExpiredException;
 import com.safeticket.order.exception.OrderNotFoundException;
 import com.safeticket.order.repository.OrderRepository;
+import org.aspectj.weaver.ast.Or;
+import org.redisson.api.RBatch;
+import org.redisson.api.RLock;
+import org.redisson.api.RedissonClient;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Instant;
+import java.util.concurrent.TimeUnit;
 
 @Service
 public class OrderServiceImpl implements OrderService {
@@ -20,15 +31,21 @@ public class OrderServiceImpl implements OrderService {
     @Autowired
     private PaymentService paymentService;
 
+    @Autowired
+    private RedissonClient redissonClient;
+
+    @Autowired
+    private RedisTemplate<String, Object> redisTemplate;
+
+    @Value("${redis.lock.ticket.reservation.lease-time-seconds}")
+    private long leaseTimeSeconds;
+
     @Override
     @Transactional
     public OrderDTO createOrder(OrderDTO orderDTO) {
-        Order order = Order.builder()
-                .userId(orderDTO.getUserId())
-                .amount(orderDTO.getAmount())
-                .ticketIds(orderDTO.getTicketIds())
-                .status(OrderStatus.PENDING)
-                .build();
+        validateAndExtendReservationLock(orderDTO);
+
+        Order order = createOrderEntity(orderDTO, OrderStatus.PENDING);
         orderRepository.save(order);
 
         paymentService.processPayment(order);
@@ -42,5 +59,36 @@ public class OrderServiceImpl implements OrderService {
                 .orElseThrow(() -> new OrderNotFoundException(String.valueOf(orderDTO.getUserId())));
         order.updateStatus(OrderStatus.valueOf(orderDTO.getStatus()));
         orderRepository.save(order);
+    }
+
+    private Order createOrderEntity(OrderDTO orderDTO, OrderStatus orderStatus) {
+        return Order.builder()
+                .userId(orderDTO.getUserId())
+                .amount(orderDTO.getAmount())
+                .ticketIds(orderDTO.getTicketIds())
+                .status(orderStatus)
+                .build();
+    }
+
+    public void validateAndExtendReservationLock(OrderDTO orderDTO) {
+        RBatch batch = redissonClient.createBatch();
+
+        for (Long ticketId : orderDTO.getTicketIds()) {
+            String lockKey = RedisKeyUtil.getReservationLockKey(orderDTO.getUserId(), ticketId);
+            Long ttl = redisTemplate.getExpire(lockKey, TimeUnit.SECONDS);
+
+            if (ttl <= 0) {
+                throw new OrderCreationLockExpiredException();
+            }
+
+            Instant expirationTime =Instant.ofEpochSecond(leaseTimeSeconds);
+            batch.getBucket(lockKey).expireAsync(expirationTime);
+        }
+
+        try {
+            batch.execute();
+        } catch (Exception e) {
+            throw new OrderCreationLockExpiredException();
+        }
     }
 }

--- a/order/src/main/java/com/safeticket/order/service/OrderServiceImpl.java
+++ b/order/src/main/java/com/safeticket/order/service/OrderServiceImpl.java
@@ -1,0 +1,46 @@
+package com.safeticket.order.service;
+
+import com.safeticket.order.dto.OrderDTO;
+import com.safeticket.order.dto.PaymentDTO;
+import com.safeticket.order.entity.Order;
+import com.safeticket.order.entity.OrderStatus;
+import com.safeticket.order.exception.OrderNotFoundException;
+import com.safeticket.order.repository.OrderRepository;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class OrderServiceImpl implements OrderService {
+
+    @Autowired
+    private OrderRepository orderRepository;
+
+    @Autowired
+    private PaymentService paymentService;
+
+    @Override
+    @Transactional
+    public OrderDTO createOrder(OrderDTO orderDTO) {
+        Order order = Order.builder()
+                .userId(orderDTO.getUserId())
+                .amount(orderDTO.getAmount())
+                .ticketIds(orderDTO.getTicketIds())
+                .status(OrderStatus.PENDING)
+                .build();
+        orderRepository.save(order);
+
+        paymentService.processPayment(order);
+
+        return OrderDTO.convert(order);
+    }
+
+    @Override
+    public void updateOrderStatus(OrderDTO orderDTO) {
+        Order order = orderRepository.findById(orderDTO.getUserId())
+                .orElseThrow(() -> new OrderNotFoundException(String.valueOf(orderDTO.getUserId())));
+        order.updateStatus(OrderStatus.valueOf(orderDTO.getStatus()));
+        orderRepository.save(order);
+    }
+}

--- a/order/src/main/java/com/safeticket/order/service/PaymentService.java
+++ b/order/src/main/java/com/safeticket/order/service/PaymentService.java
@@ -1,0 +1,7 @@
+package com.safeticket.order.service;
+
+import com.safeticket.order.entity.Order;
+
+public interface PaymentService {
+    void processPayment(Order order);
+}

--- a/order/src/main/java/com/safeticket/order/service/PaymentServiceImpl.java
+++ b/order/src/main/java/com/safeticket/order/service/PaymentServiceImpl.java
@@ -1,0 +1,42 @@
+package com.safeticket.order.service;
+
+import com.safeticket.order.dto.PaymentDTO;
+import com.safeticket.order.entity.Order;
+import com.safeticket.order.exception.PaymentProcessingException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+@Service
+public class PaymentServiceImpl implements PaymentService {
+
+    @Autowired
+    private RabbitTemplate rabbitTemplate;
+
+    @Value("${rabbitmq.queue.payment}")
+    private String paymentQueue;
+
+    private static final Logger logger = LoggerFactory.getLogger(PaymentServiceImpl.class);
+
+    @Override
+    public void processPayment(Order order) {
+        try {
+            PaymentDTO paymentRequest = convertToPaymentDTO(order);
+            rabbitTemplate.convertAndSend(paymentQueue, paymentRequest);
+        } catch(Exception e) {
+            logger.error("processPayment 오류 userId: {}", order.getUserId(), e);
+            throw new PaymentProcessingException(String.valueOf(order.getId()));
+        }
+    }
+
+    private PaymentDTO convertToPaymentDTO(Order order) {
+        return PaymentDTO.builder()
+                .orderId(order.getId())
+                .userId(order.getUserId())
+                .amount(order.getAmount())
+                .build();
+    }
+}

--- a/order/src/main/java/com/safeticket/order/service/PaymentServiceImpl.java
+++ b/order/src/main/java/com/safeticket/order/service/PaymentServiceImpl.java
@@ -9,6 +9,8 @@ import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 public class PaymentServiceImpl implements PaymentService {
@@ -22,6 +24,7 @@ public class PaymentServiceImpl implements PaymentService {
     private static final Logger logger = LoggerFactory.getLogger(PaymentServiceImpl.class);
 
     @Override
+    @Transactional(propagation = Propagation.REQUIRED)
     public void processPayment(Order order) {
         try {
             PaymentDTO paymentRequest = convertToPaymentDTO(order);

--- a/order/src/test/java/com/safeticket/order/OrderControllerTest.java
+++ b/order/src/test/java/com/safeticket/order/OrderControllerTest.java
@@ -59,7 +59,7 @@ class OrderControllerTest {
         when(orderService.createOrder(any(OrderDTO.class))).thenReturn(orderDTO);
 
         // when
-        mockMvc.perform(post("/api/orders")
+        mockMvc.perform(post("/orders")
                         .contentType("application/json")
                         .content("{\"userId\": 1, \"amount\": 1000000, \"ticketIds\": [1, 2]}"))
                 .andExpect(status().isCreated())
@@ -76,7 +76,7 @@ class OrderControllerTest {
         when(orderService.createOrder(any(OrderDTO.class))).thenThrow(new PaymentProcessingException(String.valueOf(orderDTO.getOrderId())));
 
         // when
-        mockMvc.perform(post("/api/orders")
+        mockMvc.perform(post("/orders")
                         .contentType("application/json")
                         .content("{\"userId\": 1, \"amount\": 1000000, \"ticketIds\": [1, 2]}"))
                 .andExpect(status().isInternalServerError());

--- a/order/src/test/java/com/safeticket/order/OrderControllerTest.java
+++ b/order/src/test/java/com/safeticket/order/OrderControllerTest.java
@@ -1,0 +1,87 @@
+package com.safeticket.order;
+
+import com.safeticket.common.advice.GlobalExceptionHandler;
+import com.safeticket.order.controller.OrderController;
+import com.safeticket.order.dto.OrderDTO;
+import com.safeticket.order.entity.OrderStatus;
+import com.safeticket.order.exception.PaymentProcessingException;
+import com.safeticket.order.service.OrderService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+
+@ExtendWith(MockitoExtension.class)
+class OrderControllerTest {
+
+    @Mock
+    private OrderService orderService;
+
+    @InjectMocks
+    private OrderController orderController;
+
+    MockMvc mockMvc;
+
+    OrderDTO orderDTO;
+
+    @BeforeEach
+    void setUp() {
+        mockMvc = MockMvcBuilders.standaloneSetup(orderController)
+                .setControllerAdvice(new GlobalExceptionHandler())
+                .build();
+
+        orderDTO = OrderDTO.builder()
+                .orderId(1L)
+                .userId(1L)
+                .amount(100)
+                .ticketIds(List.of(1L, 2L))
+                .status(OrderStatus.PENDING.getCode())
+                .build();
+    }
+
+    @Test
+    public void createOrderShouldReturnPendingStatus() throws Exception {
+        // given
+        when(orderService.createOrder(any(OrderDTO.class))).thenReturn(orderDTO);
+
+        // when
+        mockMvc.perform(post("/api/orders")
+                        .contentType("application/json")
+                        .content("{\"userId\": 1, \"amount\": 1000000, \"ticketIds\": [1, 2]}"))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.orderId").value(1L))
+                .andExpect(jsonPath("$.status").value("PD"));
+
+        // then
+        verify(orderService).createOrder(any(OrderDTO.class));
+    }
+
+    @Test
+    public void createOrderShouldReturnBadRequest() throws Exception {
+        // given
+        when(orderService.createOrder(any(OrderDTO.class))).thenThrow(new PaymentProcessingException(String.valueOf(orderDTO.getOrderId())));
+
+        // when
+        mockMvc.perform(post("/api/orders")
+                        .contentType("application/json")
+                        .content("{\"userId\": 1, \"amount\": 1000000, \"ticketIds\": [1, 2]}"))
+                .andExpect(status().isInternalServerError());
+
+        // then
+        verify(orderService).createOrder(any(OrderDTO.class));
+    }
+}

--- a/order/src/test/java/com/safeticket/order/OrderServiceTest.java
+++ b/order/src/test/java/com/safeticket/order/OrderServiceTest.java
@@ -84,7 +84,7 @@ class OrderServiceTest {
 
         // then
         verify(redissonClient).createBatch();
-        verify(redisTemplate, times(orderDTO.getTicketIds().size())).getExpire(anyString(), eq(TimeUnit.SECONDS));
+        verify(redisTemplate, times(orderDTO.getTicketIds().size() * 2)).getExpire(anyString(), eq(TimeUnit.SECONDS));
         verify(orderRepository).save(any(Order.class));
         verify(paymentService).processPayment(any(Order.class));
 
@@ -130,9 +130,9 @@ class OrderServiceTest {
 
         // then
         verify(redissonClient).createBatch();
-        verify(redisTemplate, times(orderDTO.getTicketIds().size())).getExpire(anyString(), eq(TimeUnit.SECONDS));
-        verify(batch, times(orderDTO.getTicketIds().size())).getBucket(anyString());
-        verify(bucket, times(orderDTO.getTicketIds().size())).expireAsync(any(Instant.class));
+        verify(redisTemplate, times(orderDTO.getTicketIds().size() * 2)).getExpire(anyString(), eq(TimeUnit.SECONDS));
+        verify(batch, times(orderDTO.getTicketIds().size() * 2)).getBucket(anyString());
+        verify(bucket, times(orderDTO.getTicketIds().size() * 2)).expireAsync(any(Instant.class));
     }
 
     @Test

--- a/order/src/test/java/com/safeticket/order/OrderServiceTest.java
+++ b/order/src/test/java/com/safeticket/order/OrderServiceTest.java
@@ -1,0 +1,98 @@
+package com.safeticket.order;
+
+import com.safeticket.order.dto.OrderDTO;
+import com.safeticket.order.entity.Order;
+import com.safeticket.order.entity.OrderStatus;
+import com.safeticket.order.exception.OrderNotFoundException;
+import com.safeticket.order.repository.OrderRepository;
+import com.safeticket.order.service.OrderServiceImpl;
+import com.safeticket.order.service.PaymentService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Arrays;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.times;
+
+@ExtendWith(MockitoExtension.class)
+class OrderServiceTest {
+
+    @Mock
+    private OrderRepository orderRepository;
+
+    @Mock
+    private PaymentService paymentService;
+
+    @InjectMocks
+    private OrderServiceImpl orderService;
+
+    private OrderDTO orderDTO;
+    private Order order;
+
+    @BeforeEach
+    void setUp() {
+        orderDTO = OrderDTO.builder()
+                .userId(1L)
+                .amount(100000)
+                .ticketIds(Arrays.asList(1L, 2L))
+                .status(OrderStatus.PENDING.name())
+                .build();
+
+        order = Order.builder()
+                .userId(1L)
+                .amount(100000)
+                .ticketIds(Arrays.asList(1L, 2L))
+                .status(OrderStatus.PENDING)
+                .build();
+    }
+
+    @Test
+    public void createOrderShouldSaveOrderAndProcessPayment() {
+        // given
+        when(orderRepository.save(any(Order.class))).thenReturn(order);
+
+        // when
+        OrderDTO createdOrder = orderService.createOrder(orderDTO);
+
+        // then
+        verify(orderRepository).save(any(Order.class));
+        verify(paymentService).processPayment(any(Order.class));
+
+        assertThat(createdOrder.getUserId()).isEqualTo(order.getUserId());
+        assertThat(createdOrder.getAmount()).isEqualTo(order.getAmount());
+        assertThat(createdOrder.getTicketIds()).isEqualTo(order.getTicketIds());
+    }
+
+    @Test
+    void updateOrderStatusShouldUpdateOrderStatus() {
+        // given
+        when(orderRepository.findById(orderDTO.getUserId())).thenReturn(Optional.of(order));
+
+        // when
+        orderService.updateOrderStatus(orderDTO);
+
+        // then
+        verify(orderRepository, times(1)).findById(orderDTO.getUserId());
+        verify(orderRepository, times(1)).save(any(Order.class));
+        assertEquals(OrderStatus.valueOf(orderDTO.getStatus()), order.getStatus());
+    }
+
+    @Test
+    void updateOrderStatusShouldThrowOrderNotFoundException() {
+        // given
+        when(orderRepository.findById(orderDTO.getUserId())).thenReturn(Optional.empty());
+
+        // when & then
+        assertThrows(OrderNotFoundException.class, () -> orderService.updateOrderStatus(orderDTO));
+    }
+}

--- a/order/src/test/java/com/safeticket/order/PaymentServiceTest.java
+++ b/order/src/test/java/com/safeticket/order/PaymentServiceTest.java
@@ -1,0 +1,72 @@
+package com.safeticket.order;
+
+
+import com.safeticket.order.dto.PaymentDTO;
+import com.safeticket.order.entity.Order;
+import com.safeticket.order.exception.PaymentProcessingException;
+import com.safeticket.order.service.PaymentServiceImpl;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.beans.factory.annotation.Value;
+
+import java.util.Arrays;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class PaymentServiceTest {
+
+    @Mock
+    private RabbitTemplate rabbitTemplate;
+
+    @InjectMocks
+    private PaymentServiceImpl paymentService;
+
+    @Value("${rabbitmq.queue.payment}")
+    private String paymentQueue;
+
+    Order order;
+
+    @BeforeEach
+    void setUp(){
+        order = Order.builder()
+                .id(1L)
+                .userId(1L)
+                .amount(100000)
+                .build();
+    }
+
+    @Test
+    public void processPaymentShouldSendPaymentRequest() {
+        // given
+        doNothing().when(rabbitTemplate).convertAndSend(eq(paymentQueue), any(PaymentDTO.class));
+
+        // when
+        paymentService.processPayment(order);
+
+        // then
+        verify(rabbitTemplate).convertAndSend(eq(paymentQueue), any(PaymentDTO.class));
+    }
+
+    @Test
+    public void processPaymentShouldThrowPaymentProcessingException() {
+        // given
+        doThrow(new PaymentProcessingException(String.valueOf(1L))).when(rabbitTemplate).convertAndSend(anyString(), any(PaymentDTO.class));
+
+        // when
+        PaymentProcessingException exception = assertThrows(PaymentProcessingException.class, () -> {
+            paymentService.processPayment(order);
+        });
+
+        // then
+        assertNotNull(exception);
+        assertTrue(exception.getMessage().contains("주문번호:1"));
+    }
+}


### PR DESCRIPTION
📌 변경 사항
- OrderController 생성: 주문 생성하는 API controller
- Order 엔티티 생성: 주문 정보를 담는 엔티티 클래스
- OrderServiceImpl 생성: 주문 관련 비즈니스 로직을 처리하는 서비스 클래스
- OrderControllerTest 생성: OrderController의 테스트 코드
- OrderServiceTest 생성: OrderServiceImpl의 테스트 코드
 
 🤔 고민한 점
- 주문 생성 시 validateAndExtendReservationLock 메서드에서 lock 권한 확인과 만료시간 연장 로직을 구현하였습니다.